### PR TITLE
Updated project schema to include links to publication schema

### DIFF
--- a/project_schema.json
+++ b/project_schema.json
@@ -119,6 +119,24 @@
                 "$ref" : "grant_schema.json#"
             }
     },
+    "primaryPublications" : {
+      "description": "The primary publication(s) associated with the project.",
+      "type" : "array",
+      "items" : {
+          "$ref" : "publication_schema.json#"
+      }
+    },
+    "citations" : {
+        "description": "The publication(s) that cite this project.",
+        "type" : "array",
+        "items" : {
+            "$ref" : "publication_schema.json#"
+        }
+    },
+    "citationCount": {
+        "description": "The number of publications that cite this project",
+        "type": "integer"
+    },
     "extraProperties": {
       "description": "Extra properties that do not fit in the previous specified attributes. ",
       "type": "array",


### PR DESCRIPTION
I have replicated the publication fields for dataset publications (primary_publications, citations, citation_count) at project level.